### PR TITLE
Disable 5-finger reboot in ploopyco/pavonis:default

### DIFF
--- a/keyboards/ploopyco/pavonis/keymaps/default/config.h
+++ b/keyboards/ploopyco/pavonis/keymaps/default/config.h
@@ -1,4 +1,2 @@
 // Copyright 2024 George Norton (@george-norton)
 // SPDX-License-Identifier: GPL-2.0-or-later
-
-#define MAXTOUCH_BOOTLOADER_GESTURE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

When I started using my trackpad I noticed that it would occasionally crash and re-appear as a mass storage device. No sweat, I could unplug/plug and I was back to the races. I poked around a little and found that the "5-finger bootloader" is a feature, not a bug, but I don't think that it should be enabled on non-debug "default" builds.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* This change removes the MAXTOUCH_BOOTLOADER_GESTURE macro in the default keymap's config.h so 5-finger reboot so bootloader is disabled.

## Checklist

Since I'm submitting this to a fork, and not the main QMK project, I just built it, loaded it, and verified that tapping the pad with 5 fingers does not bring up the bootloader.
