### PR TITLE
Do not send events while in the deadzone

### DIFF
--- a/drivers/sensors/tmag5273axial.c
+++ b/drivers/sensors/tmag5273axial.c
@@ -181,6 +181,9 @@ report_tmag5273axial_t tmag5273axial_read(void) {
             if( y_zeropoint_online_calibration < -TMAG5273AXIAL_ONLINE_CAL_THRESH ) {
                 y_zeropoint_online_calibration = -TMAG5273AXIAL_ONLINE_CAL_THRESH;
             }
+
+            // Do not report movement within the deadzone
+            return report;
         }
 
         // Scaling factor arbitrary; power of 2 (cheap) and approximately correct (based on sensor ADC range).


### PR DESCRIPTION
## Description

While we are performing online calibration, we also send events. This causing us to move a little until the zero point aligns with the current reading, then we stop moving. When the user releases the nub and it returns to  true zero, we generate more events and drift.

This PR drops events while we are in the deadzone.